### PR TITLE
Setup maven repo

### DIFF
--- a/backend/peerprep-api-gateway/pom.xml
+++ b/backend/peerprep-api-gateway/pom.xml
@@ -109,6 +109,11 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>repsy</id>
+            <name>My Private Maven Repository on Repsy</name>
+            <url>https://repo.repsy.io/mvn/adamoh/peerprep</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>

--- a/backend/peerprep-common/pom.xml
+++ b/backend/peerprep-common/pom.xml
@@ -50,6 +50,14 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>repsy</id>
+            <name>My Private Maven Repository on Repsy</name>
+            <url>https://repo.repsy.io/mvn/adamoh/peerprep</url>
+        </repository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/backend/peerprep-matching-service/pom.xml
+++ b/backend/peerprep-matching-service/pom.xml
@@ -45,6 +45,14 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>repsy</id>
+            <name>My Private Maven Repository on Repsy</name>
+            <url>https://repo.repsy.io/mvn/adamoh/peerprep</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>

--- a/backend/peerprep-question-service/pom.xml
+++ b/backend/peerprep-question-service/pom.xml
@@ -60,6 +60,14 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>repsy</id>
+            <name>My Private Maven Repository on Repsy</name>
+            <url>https://repo.repsy.io/mvn/adamoh/peerprep</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
For microservices to be able to access the shared library when deployed

For deploying a new jar, run `mvn deploy` in peerprep-common. this requires local ~/.m2/settings.xml to have the credentials

Accessing the library should be automatic